### PR TITLE
BB <-> TD Shuttles

### DIFF
--- a/butcher/Glisse_Bluesea.lua
+++ b/butcher/Glisse_Bluesea.lua
@@ -11,11 +11,11 @@ function event_signal(e)
         e.self:Shout("The Maiden's Voyage has departed the outpost at Firiona Vie. Please be ready to board the shuttles shortly, if you desire to make the journey to Kunark.");
     end
 
-	if(e.signal == 2) then
-		e.self:Shout("The Maiden's Voyage is now ready to be boarded. Please form an orderly line to the shuttles, and remember, no pushing!");
-		eq.signal(846, 1);
-		eq.signal(847, 1);
-		eq.signal(848, 1);
-		eq.signal(849, 1);
-	end
- end
+    if(e.signal == 2) then
+        e.self:Shout("The Maiden's Voyage is now ready to be boarded. Please form an orderly line to the shuttles, and remember, no pushing!");
+        eq.signal(846, 1);
+        eq.signal(847, 1);
+        eq.signal(848, 1);
+        eq.signal(849, 1);
+    end
+end

--- a/butcher/Glisse_Bluesea.lua
+++ b/butcher/Glisse_Bluesea.lua
@@ -1,0 +1,21 @@
+function event_spawn(e)
+    -- enable Shuttles on initial zone start
+    eq.spawn_condition("butcher",3,1);
+    eq.spawn_condition("butcher",4,1);
+    eq.spawn_condition("butcher",5,1);
+    eq.spawn_condition("butcher",6,1);
+end
+
+function event_signal(e)
+    if(e.signal == 1) then
+        e.self:Shout("The Maiden's Voyage has departed the outpost at Firiona Vie. Please be ready to board the shuttles shortly, if you desire to make the journey to Kunark.");
+    end
+
+	if(e.signal == 2) then
+		e.self:Shout("The Maiden's Voyage is now ready to be boarded. Please form an orderly line to the shuttles, and remember, no pushing!");
+		eq.signal(846, 1);
+		eq.signal(847, 1);
+		eq.signal(848, 1);
+		eq.signal(849, 1);
+	end
+ end

--- a/butcher/Shuttle_I.lua
+++ b/butcher/Shuttle_I.lua
@@ -1,39 +1,39 @@
 function event_spawn(e)
-	local zone_time = eq.get_zone_time();
-	local hour = zone_time["zone_hour"];
-	local minute = zone_time["zone_minute"];
-	e.self:Say("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+    local zone_time = eq.get_zone_time();
+    local hour = zone_time["zone_hour"];
+    local minute = zone_time["zone_minute"];
+    eq.debug("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
     eq.start(20);
 end
 
 function event_signal(e)
-	if(e.signal == 1) then
-		eq.start(16);
-	end
- end
+    if(e.signal == 1) then
+        eq.start(16);
+    end
+end
 
 function event_waypoint_arrive(e)
-	local zone_time = eq.get_zone_time();
-	local hour = zone_time["zone_hour"];
-	local minute = zone_time["zone_minute"];
+    local zone_time = eq.get_zone_time();
+    local hour = zone_time["zone_hour"];
+    local minute = zone_time["zone_minute"];
     if(e.gridid == 20 and e.wp == 11) then
         eq.stop();
-        eq.move_to(3157, 879, -12, 65.27, true);
+        eq.move_to(3157, 877, -12, 65.27, true);
     end
-	if(e.gridid == 16 and e.wp == 11) then
+    if(e.gridid == 16 and e.wp == 11) then
         eq.spawn_condition("butcher",3,0);
         eq.spawn_condition("timorous",5,1);
-		eq.debug("Shuttle to timorous (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
-		eq.get_entity_list():ForeachClient(
-			function(ent)
-				ent:MovePC(96, -7580, 3620, 19, 0);
-			end,
-			function(ent)
-				if(ent:GetBoatID() == 846) then
-					return true;
-				end
-				return false;
-			end
-		);
-	end
+        eq.debug("Shuttle to timorous (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+        eq.get_entity_list():ForeachClient(
+            function(ent)
+                ent:MovePC(96, -7580, 3620, 19, 72);
+            end,
+            function(ent)
+                if(ent:GetBoatID() == 846) then
+                    return true;
+                end
+                return false;
+            end
+        );
+    end
 end

--- a/butcher/Shuttle_I.lua
+++ b/butcher/Shuttle_I.lua
@@ -1,0 +1,39 @@
+function event_spawn(e)
+	local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+	e.self:Say("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+    eq.start(20);
+end
+
+function event_signal(e)
+	if(e.signal == 1) then
+		eq.start(16);
+	end
+ end
+
+function event_waypoint_arrive(e)
+	local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+    if(e.gridid == 20 and e.wp == 11) then
+        eq.stop();
+        eq.move_to(3157, 879, -12, 65.27, true);
+    end
+	if(e.gridid == 16 and e.wp == 11) then
+        eq.spawn_condition("butcher",3,0);
+        eq.spawn_condition("timorous",5,1);
+		eq.debug("Shuttle to timorous (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+		eq.get_entity_list():ForeachClient(
+			function(ent)
+				ent:MovePC(96, -7580, 3620, 19, 0);
+			end,
+			function(ent)
+				if(ent:GetBoatID() == 846) then
+					return true;
+				end
+				return false;
+			end
+		);
+	end
+end

--- a/butcher/Shuttle_I.lua
+++ b/butcher/Shuttle_I.lua
@@ -20,16 +20,38 @@ function event_waypoint_arrive(e)
         eq.stop();
         eq.move_to(3157, 877, -12, 65.27, true);
     end
-    if(e.gridid == 16 and e.wp == 11) then
+    if(e.gridid == 16 and e.wp == 12) then
         eq.spawn_condition("butcher",3,0);
         eq.spawn_condition("timorous",5,1);
         eq.debug("Shuttle to timorous (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
         eq.get_entity_list():ForeachClient(
             function(ent)
+                ent:Signal(1);
+            end,
+            function(ent)
+                local px = ent:GetX();
+                local py = ent:GetY();
+                local boat_id = ent:GetBoatID();
+                local diff_boat_check = boat_id == 847 or boat_id == 848 or boat_id == 849;
+                -- bounding box of Shuttle_I
+                local valid_pos_check = px >= 3567 and px <= 3655 and py >= 480 and py <= 504;
+                -- Server thinks we're on Shuttle_II, Shuttle_III or Shuttle_IV and are about to zone.
+                if(diff_boat_check and valid_pos_check) then
+                    return true;
+                end
+                return false;
+            end
+        );
+        eq.get_entity_list():ForeachClient(
+            function(ent)
                 ent:MovePC(96, -7580, 3620, 19, 72);
             end,
             function(ent)
-                if(ent:GetBoatID() == 846) then
+                local px = ent:GetX();
+                local py = ent:GetY();
+                -- bounding box of Shuttle_I
+                local valid_pos_check = px >= 3567 and px <= 3655 and py >= 480 and py <= 504;
+                if(ent:GetBoatID() == 846 and valid_pos_check) then
                     return true;
                 end
                 return false;

--- a/butcher/Shuttle_II.lua
+++ b/butcher/Shuttle_II.lua
@@ -1,39 +1,39 @@
 function event_spawn(e)
-	local zone_time = eq.get_zone_time();
-	local hour = zone_time["zone_hour"];
-	local minute = zone_time["zone_minute"];
-	e.self:Say("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+    local zone_time = eq.get_zone_time();
+    local hour = zone_time["zone_hour"];
+    local minute = zone_time["zone_minute"];
+    eq.debug("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
     eq.start(21);
 end
 
 function event_signal(e)
-	if(e.signal == 1) then
-		eq.start(17);
-	end
- end
+    if(e.signal == 1) then
+        eq.start(17);
+    end
+end
 
 function event_waypoint_arrive(e)
-	local zone_time = eq.get_zone_time();
-	local hour = zone_time["zone_hour"];
-	local minute = zone_time["zone_minute"];
+    local zone_time = eq.get_zone_time();
+    local hour = zone_time["zone_hour"];
+    local minute = zone_time["zone_minute"];
     if(e.gridid == 21 and e.wp == 11) then
         eq.stop();
-        eq.move_to(3158, 834, -13, 65.27, true);
+        eq.move_to(3158, 836, -13, 65.27, true);
     end
-	if(e.gridid == 17 and e.wp == 11) then
+    if(e.gridid == 17 and e.wp == 11) then
         eq.spawn_condition("butcher",4,0);
-		eq.spawn_condition("timorous",6,1);
-		eq.debug("Shuttle to timorous (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
-		eq.get_entity_list():ForeachClient(
-			function(ent)
-				ent:MovePC(96, -7580, 3580, 19, 0);
-			end,
-			function(ent)
-				if(ent:GetBoatID() == 847) then
-					return true;
-				end
-				return false;
-			end
-		);
-	end
+        eq.spawn_condition("timorous",6,1);
+        eq.debug("Shuttle to timorous (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+        eq.get_entity_list():ForeachClient(
+            function(ent)
+                ent:MovePC(96, -7580, 3580, 19, 72);
+            end,
+            function(ent)
+                if(ent:GetBoatID() == 847) then
+                    return true;
+                end
+                return false;
+            end
+        );
+    end
 end

--- a/butcher/Shuttle_II.lua
+++ b/butcher/Shuttle_II.lua
@@ -1,0 +1,39 @@
+function event_spawn(e)
+	local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+	e.self:Say("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+    eq.start(21);
+end
+
+function event_signal(e)
+	if(e.signal == 1) then
+		eq.start(17);
+	end
+ end
+
+function event_waypoint_arrive(e)
+	local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+    if(e.gridid == 21 and e.wp == 11) then
+        eq.stop();
+        eq.move_to(3158, 834, -13, 65.27, true);
+    end
+	if(e.gridid == 17 and e.wp == 11) then
+        eq.spawn_condition("butcher",4,0);
+		eq.spawn_condition("timorous",6,1);
+		eq.debug("Shuttle to timorous (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+		eq.get_entity_list():ForeachClient(
+			function(ent)
+				ent:MovePC(96, -7580, 3580, 19, 0);
+			end,
+			function(ent)
+				if(ent:GetBoatID() == 847) then
+					return true;
+				end
+				return false;
+			end
+		);
+	end
+end

--- a/butcher/Shuttle_II.lua
+++ b/butcher/Shuttle_II.lua
@@ -20,16 +20,38 @@ function event_waypoint_arrive(e)
         eq.stop();
         eq.move_to(3158, 836, -13, 65.27, true);
     end
-    if(e.gridid == 17 and e.wp == 11) then
+    if(e.gridid == 17 and e.wp == 12) then
         eq.spawn_condition("butcher",4,0);
         eq.spawn_condition("timorous",6,1);
         eq.debug("Shuttle to timorous (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
         eq.get_entity_list():ForeachClient(
             function(ent)
+                ent:Signal(2);
+            end,
+            function(ent)
+                local px = ent:GetX();
+                local py = ent:GetY();
+                local boat_id = ent:GetBoatID();
+                local diff_boat_check = boat_id == 846 or boat_id == 848 or boat_id == 849;
+                -- bounding box of Shuttle_II
+                local valid_pos_check = px >= 3567 and px <= 3655 and py >= 440 and py <= 464;
+                -- Server thinks we're on Shuttle_I, Shuttle_III or Shuttle_IV and are about to zone.
+                if(diff_boat_check and valid_pos_check) then
+                    return true;
+                end
+                return false;
+            end
+        );
+        eq.get_entity_list():ForeachClient(
+            function(ent)
                 ent:MovePC(96, -7580, 3580, 19, 72);
             end,
             function(ent)
-                if(ent:GetBoatID() == 847) then
+                local px = ent:GetX();
+                local py = ent:GetY();
+                -- bounding box of Shuttle_II
+                local valid_pos_check = px >= 3567 and px <= 3655 and py >= 440 and py <= 464;
+                if(ent:GetBoatID() == 847 and valid_pos_check) then
                     return true;
                 end
                 return false;

--- a/butcher/Shuttle_III.lua
+++ b/butcher/Shuttle_III.lua
@@ -1,39 +1,39 @@
 function event_spawn(e)
-	local zone_time = eq.get_zone_time();
-	local hour = zone_time["zone_hour"];
-	local minute = zone_time["zone_minute"];
-	e.self:Say("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+    local zone_time = eq.get_zone_time();
+    local hour = zone_time["zone_hour"];
+    local minute = zone_time["zone_minute"];
+    eq.debug("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
     eq.start(22);
 end
 
 function event_signal(e)
-	if(e.signal == 1) then
-		eq.start(18);
-	end
- end
+    if(e.signal == 1) then
+        eq.start(18);
+    end
+end
 
 function event_waypoint_arrive(e)
-	local zone_time = eq.get_zone_time();
-	local hour = zone_time["zone_hour"];
-	local minute = zone_time["zone_minute"];
+    local zone_time = eq.get_zone_time();
+    local hour = zone_time["zone_hour"];
+    local minute = zone_time["zone_minute"];
     if(e.gridid == 22 and e.wp == 11) then
         eq.stop();
-        eq.move_to(3067, 834, -13, 65.27, true);
+        eq.move_to(3067, 836, -13, 65.27, true);
     end
-	if(e.gridid == 18 and e.wp == 11) then
+    if(e.gridid == 18 and e.wp == 11) then
         eq.spawn_condition("butcher",5,0);
         eq.spawn_condition("timorous",7,1);
-		eq.debug("Shuttle to timorous (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
-		eq.get_entity_list():ForeachClient(
-			function(ent)
-				ent:MovePC(96, -7665, 3580, 19, 0);
-			end,
-			function(ent)
-				if(ent:GetBoatID() == 848) then
-					return true;
-				end
-				return false;
-			end
-		);
-	end
+        eq.debug("Shuttle to timorous (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+        eq.get_entity_list():ForeachClient(
+            function(ent)
+                ent:MovePC(96, -7665, 3580, 19, 72);
+            end,
+            function(ent)
+                if(ent:GetBoatID() == 848) then
+                    return true;
+                end
+                return false;
+            end
+        );
+    end
 end

--- a/butcher/Shuttle_III.lua
+++ b/butcher/Shuttle_III.lua
@@ -20,16 +20,38 @@ function event_waypoint_arrive(e)
         eq.stop();
         eq.move_to(3067, 836, -13, 65.27, true);
     end
-    if(e.gridid == 18 and e.wp == 11) then
+    if(e.gridid == 18 and e.wp == 12) then
         eq.spawn_condition("butcher",5,0);
         eq.spawn_condition("timorous",7,1);
         eq.debug("Shuttle to timorous (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
         eq.get_entity_list():ForeachClient(
             function(ent)
+                ent:Signal(3);
+            end,
+            function(ent)
+                local px = ent:GetX();
+                local py = ent:GetY();
+                local boat_id = ent:GetBoatID();
+                local diff_boat_check = boat_id == 846 or boat_id == 847 or boat_id == 849;
+                -- bounding box of Shuttle_III
+                local valid_pos_check = px >= 3567 and px <= 3655 and py >= 400 and py <= 424;
+                -- Server thinks we're on Shuttle_I, Shuttle_II or Shuttle_IV and are about to zone.
+                if(diff_boat_check and valid_pos_check) then
+                    return true;
+                end
+                return false;
+            end
+        );
+        eq.get_entity_list():ForeachClient(
+            function(ent)
                 ent:MovePC(96, -7665, 3580, 19, 72);
             end,
             function(ent)
-                if(ent:GetBoatID() == 848) then
+                local px = ent:GetX();
+                local py = ent:GetY();
+                -- bounding box of Shuttle_III
+                local valid_pos_check = px >= 3567 and px <= 3655 and py >= 400 and py <= 424;
+                if(ent:GetBoatID() == 848 and valid_pos_check) then
                     return true;
                 end
                 return false;

--- a/butcher/Shuttle_III.lua
+++ b/butcher/Shuttle_III.lua
@@ -1,0 +1,39 @@
+function event_spawn(e)
+	local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+	e.self:Say("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+    eq.start(22);
+end
+
+function event_signal(e)
+	if(e.signal == 1) then
+		eq.start(18);
+	end
+ end
+
+function event_waypoint_arrive(e)
+	local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+    if(e.gridid == 22 and e.wp == 11) then
+        eq.stop();
+        eq.move_to(3067, 834, -13, 65.27, true);
+    end
+	if(e.gridid == 18 and e.wp == 11) then
+        eq.spawn_condition("butcher",5,0);
+        eq.spawn_condition("timorous",7,1);
+		eq.debug("Shuttle to timorous (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+		eq.get_entity_list():ForeachClient(
+			function(ent)
+				ent:MovePC(96, -7665, 3580, 19, 0);
+			end,
+			function(ent)
+				if(ent:GetBoatID() == 848) then
+					return true;
+				end
+				return false;
+			end
+		);
+	end
+end

--- a/butcher/Shuttle_IV.lua
+++ b/butcher/Shuttle_IV.lua
@@ -1,39 +1,39 @@
 function event_spawn(e)
-	local zone_time = eq.get_zone_time();
-	local hour = zone_time["zone_hour"];
-	local minute = zone_time["zone_minute"];
-	e.self:Say("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+    local zone_time = eq.get_zone_time();
+    local hour = zone_time["zone_hour"];
+    local minute = zone_time["zone_minute"];
+	eq.debug("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
     eq.start(23);
 end
 
 function event_signal(e)
-	if(e.signal == 1) then
-		eq.start(19);
-	end
- end
+    if(e.signal == 1) then
+        eq.start(19);
+    end
+end
 
 function event_waypoint_arrive(e)
-	local zone_time = eq.get_zone_time();
-	local hour = zone_time["zone_hour"];
-	local minute = zone_time["zone_minute"];
+    local zone_time = eq.get_zone_time();
+    local hour = zone_time["zone_hour"];
+    local minute = zone_time["zone_minute"];
     if(e.gridid == 23 and e.wp == 11) then
         eq.stop();
-        eq.move_to(3067, 879, -12, 65.27, true);
+        eq.move_to(3067, 877, -12, 65.27, true);
     end
-	if(e.gridid == 19 and e.wp == 11) then
+    if(e.gridid == 19 and e.wp == 11) then
         eq.spawn_condition("butcher",6,0);
         eq.spawn_condition("timorous",8,1);
-		eq.debug("Shuttle to timorous (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
-		eq.get_entity_list():ForeachClient(
-			function(ent)
-				ent:MovePC(96, -7665, 3620, 19, 0);
-			end,
-			function(ent)
-				if(ent:GetBoatID() == 849) then
-					return true;
-				end
-				return false;
-			end
-		);
-	end
+        eq.debug("Shuttle to timorous (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+        eq.get_entity_list():ForeachClient(
+            function(ent)
+                ent:MovePC(96, -7665, 3620, 19, 72);
+            end,
+            function(ent)
+                if(ent:GetBoatID() == 849) then
+                    return true;
+                end
+                return false;
+            end
+        );
+    end
 end

--- a/butcher/Shuttle_IV.lua
+++ b/butcher/Shuttle_IV.lua
@@ -20,16 +20,38 @@ function event_waypoint_arrive(e)
         eq.stop();
         eq.move_to(3067, 877, -12, 65.27, true);
     end
-    if(e.gridid == 19 and e.wp == 11) then
+    if(e.gridid == 19 and e.wp == 12) then
         eq.spawn_condition("butcher",6,0);
         eq.spawn_condition("timorous",8,1);
         eq.debug("Shuttle to timorous (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
         eq.get_entity_list():ForeachClient(
             function(ent)
+                ent:Signal(4);
+            end,
+            function(ent)
+                local px = ent:GetX();
+                local py = ent:GetY();
+                local boat_id = ent:GetBoatID();
+                local diff_boat_check = boat_id == 846 or boat_id == 847 or boat_id == 848;
+                -- bounding box of Shuttle_IV
+                local valid_pos_check = px >= 3567 and px <= 3655 and py >= 520 and py <= 544;
+                -- Server thinks we're on Shuttle_I, Shuttle_II or Shuttle_III and are about to zone.
+                if(diff_boat_check and valid_pos_check) then
+                    return true;
+                end
+                return false;
+            end
+        );
+        eq.get_entity_list():ForeachClient(
+            function(ent)
                 ent:MovePC(96, -7665, 3620, 19, 72);
             end,
             function(ent)
-                if(ent:GetBoatID() == 849) then
+                local px = ent:GetX();
+                local py = ent:GetY();
+                -- bounding box of Shuttle_IV
+                local valid_pos_check = px >= 3567 and px <= 3655 and py >= 520 and py <= 544;
+                if(ent:GetBoatID() == 849 and valid_pos_check) then
                     return true;
                 end
                 return false;

--- a/butcher/Shuttle_IV.lua
+++ b/butcher/Shuttle_IV.lua
@@ -1,0 +1,39 @@
+function event_spawn(e)
+	local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+	e.self:Say("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+    eq.start(23);
+end
+
+function event_signal(e)
+	if(e.signal == 1) then
+		eq.start(19);
+	end
+ end
+
+function event_waypoint_arrive(e)
+	local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+    if(e.gridid == 23 and e.wp == 11) then
+        eq.stop();
+        eq.move_to(3067, 879, -12, 65.27, true);
+    end
+	if(e.gridid == 19 and e.wp == 11) then
+        eq.spawn_condition("butcher",6,0);
+        eq.spawn_condition("timorous",8,1);
+		eq.debug("Shuttle to timorous (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+		eq.get_entity_list():ForeachClient(
+			function(ent)
+				ent:MovePC(96, -7665, 3620, 19, 0);
+			end,
+			function(ent)
+				if(ent:GetBoatID() == 849) then
+					return true;
+				end
+				return false;
+			end
+		);
+	end
+end

--- a/butcher/player.lua
+++ b/butcher/player.lua
@@ -6,6 +6,22 @@ function event_enter_zone(e)
 	end
 end
 
+function event_signal(e)
+	if(e.signal == 1) then
+		e.self:SetBoatID(846);
+		e.self:SetBoatName("Shuttle_I000");
+	elseif(e.signal == 2) then
+		e.self:SetBoatID(847);
+		e.self:SetBoatName("Shuttle_II000");
+	elseif(e.signal == 3) then
+		e.self:SetBoatID(848);
+		e.self:SetBoatName("Shuttle_III000");
+	elseif(e.signal == 4) then
+		e.self:SetBoatID(849);
+		e.self:SetBoatName("Shuttle_IV000");
+	end
+end
+
 function event_board_boat(e)
 	local zone_time = eq.get_zone_time();
 	local hour = zone_time["zone_hour"];

--- a/firiona/Maidens_Voyage.lua
+++ b/firiona/Maidens_Voyage.lua
@@ -11,7 +11,7 @@ function event_waypoint_arrive(e)
 	local minute = zone_time["zone_minute"];
 	if(e.wp == 12) then
 		eq.debug("Boat to timorous (18) has reached the docks.  Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
-	elseif(e.wp == 17) then
+    elseif(e.wp == 17) then
 		eq.debug("Boat to timorous (18) has reached waypoint 17.  Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
 	elseif(e.wp == 18) then
 		eq.debug("Boat to timorous (18) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
@@ -27,4 +27,15 @@ function event_waypoint_arrive(e)
 			end
 		);
 	end
+end
+
+function event_waypoint_depart(e)
+    local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+    if(e.wp == 12) then
+        eq.debug("Boat to timorous (18) has departed the docks. Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+        -- signal BB shuttles are going to depart soon
+        eq.signal(68236,1);
+    end
 end

--- a/timorous/Captains_Skiff.lua
+++ b/timorous/Captains_Skiff.lua
@@ -14,7 +14,7 @@ function event_signal(e)
 		eq.get_entity_list():ForeachClient(
 			function(ent)
 				ent:Signal(2);
-					end,
+			end,
 			function(ent)
 				-- Server thinks we're on Maidens_Voyage and are about to zone.
 				if(ent:GetBoatID() == 838 and ent:GetX() < -7100) then

--- a/timorous/Maidens_Voyage.lua
+++ b/timorous/Maidens_Voyage.lua
@@ -16,7 +16,6 @@ function event_waypoint_arrive(e)
 		eq.signal(96075,2); -- NPC: Island_Shuttle
 	elseif(e.wp == 18) then -- signal one before 19 to allow them to move sooner
 		eq.debug("Boat to firiona (2) has reached the shuttle. Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
-		--eq.signal(842,1); -- NPC: Captains_Skiff	
         eq.signal(846,1); -- NPC: Shuttle_I
         eq.signal(847,1); -- NPC: Shuttle_II
         eq.signal(848,1); -- NPC: Shuttle_III

--- a/timorous/Maidens_Voyage.lua
+++ b/timorous/Maidens_Voyage.lua
@@ -14,21 +14,23 @@ function event_waypoint_arrive(e)
 		eq.debug("Boat to firiona (2) has reached the Elf docks. Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
 	elseif(e.wp == 5) then
 		eq.signal(96075,2); -- NPC: Island_Shuttle
-	elseif(e.wp == 18) then -- signal one before 19 to allow them to move sooner
+	elseif(e.wp == 17) then -- signal before 19 to allow them to move sooner (we pause at 19)
 		eq.debug("Boat to firiona (2) has reached the shuttle. Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
-        eq.signal(846,1); -- NPC: Shuttle_I
-        eq.signal(847,1); -- NPC: Shuttle_II
-        eq.signal(848,1); -- NPC: Shuttle_III
-        eq.signal(849,1); -- NPC: Shuttle_IV
+		eq.signal(846,1); -- NPC: Shuttle_I
+		eq.signal(847,1); -- NPC: Shuttle_II
+		eq.signal(848,1); -- NPC: Shuttle_III
+		eq.signal(849,1); -- NPC: Shuttle_IV
 	elseif(e.wp == 30) then
 		eq.debug("Boat to firiona (2) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
 		eq.get_entity_list():ForeachClient(
 			function(ent)
 				ent:Signal(1);
-					end,
+			end,
 			function(ent)
-				-- Server thinks we're on Island_Shuttle and are about to zone.
-				if(ent:GetBoatID() == 96075 and ent:GetX() < -2000 and ent:GetY() > 500) then
+				local boat_id = ent:GetBoatID();
+				local diff_boat_check = boat_id == 96075 or boat_id == 846 or boat_id == 847 or boat_id == 848 or boat_id == 849;
+				-- Server thinks we're on Island_Shuttle, Shuttle_I, Shuttle_II, Shuttle_III or Shuttle_IV and are about to zone.
+				if(diff_boat_check and ent:GetX() < -2000 and ent:GetY() > 500) then
 					return true;
 				end
 				return false;
@@ -49,8 +51,8 @@ function event_waypoint_arrive(e)
 end
 
 function event_waypoint_depart(e)
-    if(e.wp == 5) then
-        -- signal BB shuttles to depart
-        eq.signal(68236,2);
-    end
+	if(e.wp == 5) then
+		-- signal BB shuttles to depart
+		eq.signal(68236,2);
+	end
 end

--- a/timorous/Maidens_Voyage.lua
+++ b/timorous/Maidens_Voyage.lua
@@ -14,9 +14,13 @@ function event_waypoint_arrive(e)
 		eq.debug("Boat to firiona (2) has reached the Elf docks. Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
 	elseif(e.wp == 5) then
 		eq.signal(96075,2); -- NPC: Island_Shuttle
-	elseif(e.wp == 19) then
+	elseif(e.wp == 18) then -- signal one before 19 to allow them to move sooner
 		eq.debug("Boat to firiona (2) has reached the shuttle. Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
-		eq.signal(842,1); -- NPC: Captains_Skiff	
+		--eq.signal(842,1); -- NPC: Captains_Skiff	
+        eq.signal(846,1); -- NPC: Shuttle_I
+        eq.signal(847,1); -- NPC: Shuttle_II
+        eq.signal(848,1); -- NPC: Shuttle_III
+        eq.signal(849,1); -- NPC: Shuttle_IV
 	elseif(e.wp == 30) then
 		eq.debug("Boat to firiona (2) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
 		eq.get_entity_list():ForeachClient(
@@ -43,4 +47,11 @@ function event_waypoint_arrive(e)
 			end
 		);
 	end
+end
+
+function event_waypoint_depart(e)
+    if(e.wp == 5) then
+        -- signal BB shuttles to depart
+        eq.signal(68236,2);
+    end
 end

--- a/timorous/Shuttle_I.lua
+++ b/timorous/Shuttle_I.lua
@@ -21,10 +21,32 @@ function event_waypoint_arrive(e)
         eq.debug("Shuttle to butcher (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
         eq.get_entity_list():ForeachClient(
             function(ent)
+                ent:Signal(2);
+            end,
+            function(ent)
+                local px = ent:GetX();
+                local py = ent:GetY();
+                local boat_id = ent:GetBoatID();
+                local diff_boat_check = boat_id == 838 or boat_id == 847 or boat_id == 848 or boat_id == 849 or boat_id == 96075;
+                -- bounding box of Shuttle_I
+                local valid_pos_check = px >= -7616 and px <= -7546 and py >= 3598 and py <= 3645;
+                -- Server thinks we're on Maidens_Voyage, Shuttle_II, Shuttle_III, Shuttle_IV or Island_Shuttle and are about to zone.
+                if(diff_boat_check and valid_pos_check) then
+                    return true;
+                end
+                return false;
+            end
+        );
+        eq.get_entity_list():ForeachClient(
+            function(ent)
                 ent:MovePC(68, 3595, 491, 19, 224);
             end,
             function(ent)
-                if(ent:GetBoatID() == 846) then
+                local px = ent:GetX();
+                local py = ent:GetY();
+                -- bounding box of Shuttle_I
+                local valid_pos_check = px >= -7616 and px <= -7546 and py >= 3598 and py <= 3645;
+                if(ent:GetBoatID() == 846 and valid_pos_check) then
                     return true;
                 end
                 return false;

--- a/timorous/Shuttle_I.lua
+++ b/timorous/Shuttle_I.lua
@@ -1,34 +1,34 @@
 function event_spawn(e)
-	local zone_time = eq.get_zone_time();
-	local hour = zone_time["zone_hour"];
-	local minute = zone_time["zone_minute"];
-	e.self:Say("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+    local zone_time = eq.get_zone_time();
+    local hour = zone_time["zone_hour"];
+    local minute = zone_time["zone_minute"];
+    eq.debug("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
 end
 
 function event_signal(e)
-	if(e.signal == 1) then
-		eq.start(16);
-	end
- end
+    if(e.signal == 1) then
+        eq.start(16);
+    end
+end
 
 function event_waypoint_arrive(e)
-	local zone_time = eq.get_zone_time();
-	local hour = zone_time["zone_hour"];
-	local minute = zone_time["zone_minute"];
-	if(e.gridid == 16 and e.wp == 3) then
+    local zone_time = eq.get_zone_time();
+    local hour = zone_time["zone_hour"];
+    local minute = zone_time["zone_minute"];
+    if(e.gridid == 16 and e.wp == 3) then
         eq.spawn_condition("butcher",3,1);
         eq.spawn_condition("timorous",5,0);
-		eq.debug("Shuttle to butcher (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
-		eq.get_entity_list():ForeachClient(
-			function(ent)
-				ent:MovePC(68, 3595, 530, 19, 0);
-			end,
-			function(ent)
-				if(ent:GetBoatID() == 846) then
-					return true;
-				end
-				return false;
-			end
-		);
-	end
+        eq.debug("Shuttle to butcher (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+        eq.get_entity_list():ForeachClient(
+            function(ent)
+                ent:MovePC(68, 3595, 491, 19, 224);
+            end,
+            function(ent)
+                if(ent:GetBoatID() == 846) then
+                    return true;
+                end
+                return false;
+            end
+        );
+    end
 end

--- a/timorous/Shuttle_I.lua
+++ b/timorous/Shuttle_I.lua
@@ -1,0 +1,34 @@
+function event_spawn(e)
+	local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+	e.self:Say("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+end
+
+function event_signal(e)
+	if(e.signal == 1) then
+		eq.start(16);
+	end
+ end
+
+function event_waypoint_arrive(e)
+	local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+	if(e.gridid == 16 and e.wp == 3) then
+        eq.spawn_condition("butcher",3,1);
+        eq.spawn_condition("timorous",5,0);
+		eq.debug("Shuttle to butcher (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+		eq.get_entity_list():ForeachClient(
+			function(ent)
+				ent:MovePC(68, 3595, 530, 19, 0);
+			end,
+			function(ent)
+				if(ent:GetBoatID() == 846) then
+					return true;
+				end
+				return false;
+			end
+		);
+	end
+end

--- a/timorous/Shuttle_II.lua
+++ b/timorous/Shuttle_II.lua
@@ -21,10 +21,32 @@ function event_waypoint_arrive(e)
         eq.debug("Shuttle to butcher (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
         eq.get_entity_list():ForeachClient(
             function(ent)
+                ent:Signal(3);
+            end,
+            function(ent)
+                local px = ent:GetX();
+                local py = ent:GetY();
+                local boat_id = ent:GetBoatID();
+                local diff_boat_check = boat_id == 838 or boat_id == 846 or boat_id == 848 or boat_id == 849 or boat_id == 96075;
+                -- bounding box of Shuttle_II
+                local valid_pos_check = px >= -7609 and px <= -7550 and py >= 3559 and py <= 3602;
+                -- Server thinks we're on Maidens_Voyage, Shuttle_I, Shuttle_III, Shuttle_IV or Island_Shuttle and are about to zone.
+                if(diff_boat_check and valid_pos_check) then
+                    return true;
+                end
+                return false;
+            end
+        );
+        eq.get_entity_list():ForeachClient(
+            function(ent)
                 ent:MovePC(68, 3595, 452, 19, 224);
             end,
             function(ent)
-                if(ent:GetBoatID() == 847) then
+                local px = ent:GetX();
+                local py = ent:GetY();
+                -- bounding box of Shuttle_II
+                local valid_pos_check = px >= -7609 and px <= -7550 and py >= 3559 and py <= 3602;
+                if(ent:GetBoatID() == 847 and valid_pos_check) then
                     return true;
                 end
                 return false;

--- a/timorous/Shuttle_II.lua
+++ b/timorous/Shuttle_II.lua
@@ -1,0 +1,34 @@
+function event_spawn(e)
+	local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+	e.self:Say("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+end
+
+function event_signal(e)
+	if(e.signal == 1) then
+		eq.start(17);
+	end
+ end
+
+function event_waypoint_arrive(e)
+	local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+	if(e.gridid == 17 and e.wp == 8) then
+        eq.spawn_condition("butcher",4,1);
+        eq.spawn_condition("timorous",6,0);
+		eq.debug("Shuttle to butcher (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+		eq.get_entity_list():ForeachClient(
+			function(ent)
+				ent:MovePC(68, 3595, 491, 19, 0);
+			end,
+			function(ent)
+				if(ent:GetBoatID() == 847) then
+					return true;
+				end
+				return false;
+			end
+		);
+	end
+end

--- a/timorous/Shuttle_II.lua
+++ b/timorous/Shuttle_II.lua
@@ -1,34 +1,34 @@
 function event_spawn(e)
-	local zone_time = eq.get_zone_time();
-	local hour = zone_time["zone_hour"];
-	local minute = zone_time["zone_minute"];
-	e.self:Say("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+    local zone_time = eq.get_zone_time();
+    local hour = zone_time["zone_hour"];
+    local minute = zone_time["zone_minute"];
+    eq.debug("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
 end
 
 function event_signal(e)
-	if(e.signal == 1) then
-		eq.start(17);
-	end
- end
+    if(e.signal == 1) then
+        eq.start(17);
+    end
+end
 
 function event_waypoint_arrive(e)
-	local zone_time = eq.get_zone_time();
-	local hour = zone_time["zone_hour"];
-	local minute = zone_time["zone_minute"];
-	if(e.gridid == 17 and e.wp == 8) then
+    local zone_time = eq.get_zone_time();
+    local hour = zone_time["zone_hour"];
+    local minute = zone_time["zone_minute"];
+    if(e.gridid == 17 and e.wp == 8) then
         eq.spawn_condition("butcher",4,1);
         eq.spawn_condition("timorous",6,0);
-		eq.debug("Shuttle to butcher (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
-		eq.get_entity_list():ForeachClient(
-			function(ent)
-				ent:MovePC(68, 3595, 491, 19, 0);
-			end,
-			function(ent)
-				if(ent:GetBoatID() == 847) then
-					return true;
-				end
-				return false;
-			end
-		);
+        eq.debug("Shuttle to butcher (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+        eq.get_entity_list():ForeachClient(
+            function(ent)
+                ent:MovePC(68, 3595, 452, 19, 224);
+            end,
+            function(ent)
+                if(ent:GetBoatID() == 847) then
+                    return true;
+                end
+                return false;
+            end
+        );
 	end
 end

--- a/timorous/Shuttle_III.lua
+++ b/timorous/Shuttle_III.lua
@@ -21,10 +21,32 @@ function event_waypoint_arrive(e)
         eq.debug("Shuttle to butcher (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
         eq.get_entity_list():ForeachClient(
             function(ent)
+                ent:Signal(4);
+            end,
+            function(ent)
+                local px = ent:GetX();
+                local py = ent:GetY();
+                local boat_id = ent:GetBoatID();
+                local diff_boat_check = boat_id == 838 or boat_id == 846 or boat_id == 847 or boat_id == 849 or boat_id == 96075;
+                -- bounding box of Shuttle_III
+                local valid_pos_check = px >= -7695 and px <= -7633 and py >= 3562 and py <= 3598;
+                -- Server thinks we're on Maidens_Voyage, Shuttle_I, Shuttle_II, Shuttle_IV or Island_Shuttle and are about to zone.
+                if(diff_boat_check and valid_pos_check) then
+                    return true;
+                end
+                return false;
+            end
+        );
+        eq.get_entity_list():ForeachClient(
+            function(ent)
                 ent:MovePC(68, 3595, 413, 19, 224);
             end,
             function(ent)
-                if(ent:GetBoatID() == 848) then
+                local px = ent:GetX();
+                local py = ent:GetY();
+                -- bounding box of Shuttle_III
+                local valid_pos_check = px >= -7695 and px <= -7633 and py >= 3562 and py <= 3598;
+                if(ent:GetBoatID() == 848 and valid_pos_check) then
                     return true;
                 end
                 return false;

--- a/timorous/Shuttle_III.lua
+++ b/timorous/Shuttle_III.lua
@@ -1,34 +1,34 @@
 function event_spawn(e)
-	local zone_time = eq.get_zone_time();
-	local hour = zone_time["zone_hour"];
-	local minute = zone_time["zone_minute"];
-	e.self:Say("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+    local zone_time = eq.get_zone_time();
+    local hour = zone_time["zone_hour"];
+    local minute = zone_time["zone_minute"];
+    eq.debug("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
 end
 
 function event_signal(e)
-	if(e.signal == 1) then
-		eq.start(18);
-	end
- end
+    if(e.signal == 1) then
+        eq.start(18);
+    end
+end
 
 function event_waypoint_arrive(e)
-	local zone_time = eq.get_zone_time();
-	local hour = zone_time["zone_hour"];
-	local minute = zone_time["zone_minute"];
-	if(e.gridid == 18 and e.wp == 9) then
+    local zone_time = eq.get_zone_time();
+    local hour = zone_time["zone_hour"];
+    local minute = zone_time["zone_minute"];
+    if(e.gridid == 18 and e.wp == 9) then
         eq.spawn_condition("butcher",5,1);
         eq.spawn_condition("timorous",7,0);
-		eq.debug("Shuttle to butcher (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
-		eq.get_entity_list():ForeachClient(
-			function(ent)
-				ent:MovePC(68, 3529, 556, 19, 0);
-			end,
-			function(ent)
-				if(ent:GetBoatID() == 848) then
-					return true;
-				end
-				return false;
-			end
-		);
-	end
+        eq.debug("Shuttle to butcher (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+        eq.get_entity_list():ForeachClient(
+            function(ent)
+                ent:MovePC(68, 3595, 413, 19, 224);
+            end,
+            function(ent)
+                if(ent:GetBoatID() == 848) then
+                    return true;
+                end
+                return false;
+            end
+        );
+    end
 end

--- a/timorous/Shuttle_III.lua
+++ b/timorous/Shuttle_III.lua
@@ -1,0 +1,34 @@
+function event_spawn(e)
+	local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+	e.self:Say("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+end
+
+function event_signal(e)
+	if(e.signal == 1) then
+		eq.start(18);
+	end
+ end
+
+function event_waypoint_arrive(e)
+	local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+	if(e.gridid == 18 and e.wp == 9) then
+        eq.spawn_condition("butcher",5,1);
+        eq.spawn_condition("timorous",7,0);
+		eq.debug("Shuttle to butcher (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+		eq.get_entity_list():ForeachClient(
+			function(ent)
+				ent:MovePC(68, 3529, 556, 19, 0);
+			end,
+			function(ent)
+				if(ent:GetBoatID() == 848) then
+					return true;
+				end
+				return false;
+			end
+		);
+	end
+end

--- a/timorous/Shuttle_IV.lua
+++ b/timorous/Shuttle_IV.lua
@@ -1,0 +1,34 @@
+function event_spawn(e)
+	local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+	e.self:Say("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+end
+
+function event_signal(e)
+	if(e.signal == 1) then
+		eq.start(19);
+	end
+ end
+
+function event_waypoint_arrive(e)
+	local zone_time = eq.get_zone_time();
+	local hour = zone_time["zone_hour"];
+	local minute = zone_time["zone_minute"];
+	if(e.gridid == 19 and e.wp == 4) then
+        eq.spawn_condition("butcher",6,1);
+        eq.spawn_condition("timorous",8,0);
+		eq.debug("Shuttle to butcher (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+		eq.get_entity_list():ForeachClient(
+			function(ent)
+				ent:MovePC(68, 3536, 589, 19, 0);
+			end,
+			function(ent)
+				if(ent:GetBoatID() == 849) then
+					return true;
+				end
+				return false;
+			end
+		);
+	end
+end

--- a/timorous/Shuttle_IV.lua
+++ b/timorous/Shuttle_IV.lua
@@ -21,10 +21,32 @@ function event_waypoint_arrive(e)
         eq.debug("Shuttle to butcher (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
         eq.get_entity_list():ForeachClient(
             function(ent)
+                ent:Signal(5);
+            end,
+            function(ent)
+                local px = ent:GetX();
+                local py = ent:GetY();
+                local boat_id = ent:GetBoatID();
+                local diff_boat_check = boat_id == 838 or boat_id == 846 or boat_id == 847 or boat_id == 848 or boat_id == 96075;
+                -- bounding box of Shuttle_IV
+                local valid_pos_check = px >= -7696 and px <= -7634 and py >= 3602 and py <= 3640;
+                -- Server thinks we're on Maidens_Voyage, Shuttle_I, Shuttle_II, Shuttle_III or Island_Shuttle and are about to zone.
+                if(diff_boat_check and valid_pos_check) then
+                    return true;
+                end
+                return false;
+            end
+        );
+        eq.get_entity_list():ForeachClient(
+            function(ent)
                 ent:MovePC(68, 3595, 530, 19, 224);
             end,
             function(ent)
-                if(ent:GetBoatID() == 849) then
+                local px = ent:GetX();
+                local py = ent:GetY();
+                -- bounding box of Shuttle_IV
+                local valid_pos_check = px >= -7696 and px <= -7634 and py >= 3602 and py <= 3640;
+                if(ent:GetBoatID() == 849 and valid_pos_check) then
                     return true;
                 end
                 return false;

--- a/timorous/Shuttle_IV.lua
+++ b/timorous/Shuttle_IV.lua
@@ -1,34 +1,34 @@
 function event_spawn(e)
-	local zone_time = eq.get_zone_time();
-	local hour = zone_time["zone_hour"];
-	local minute = zone_time["zone_minute"];
-	e.self:Say("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+    local zone_time = eq.get_zone_time();
+    local hour = zone_time["zone_hour"];
+    local minute = zone_time["zone_minute"];
+    eq.debug("Boat spawned! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
 end
 
 function event_signal(e)
-	if(e.signal == 1) then
-		eq.start(19);
-	end
- end
+    if(e.signal == 1) then
+        eq.start(19);
+    end
+end
 
 function event_waypoint_arrive(e)
-	local zone_time = eq.get_zone_time();
-	local hour = zone_time["zone_hour"];
-	local minute = zone_time["zone_minute"];
-	if(e.gridid == 19 and e.wp == 4) then
+    local zone_time = eq.get_zone_time();
+    local hour = zone_time["zone_hour"];
+    local minute = zone_time["zone_minute"];
+    if(e.gridid == 19 and e.wp == 4) then
         eq.spawn_condition("butcher",6,1);
         eq.spawn_condition("timorous",8,0);
-		eq.debug("Shuttle to butcher (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
-		eq.get_entity_list():ForeachClient(
-			function(ent)
-				ent:MovePC(68, 3536, 589, 19, 0);
-			end,
-			function(ent)
-				if(ent:GetBoatID() == 849) then
-					return true;
-				end
-				return false;
-			end
-		);
-	end
+        eq.debug("Shuttle to butcher (4) has reached its destination! Name is: " .. e.self:GetName() .. " Time is: " .. hour ..":" .. minute .. "", 1);
+        eq.get_entity_list():ForeachClient(
+            function(ent)
+                ent:MovePC(68, 3595, 530, 19, 224);
+            end,
+            function(ent)
+                if(ent:GetBoatID() == 849) then
+                    return true;
+                end
+                return false;
+            end
+        );
+    end
 end

--- a/timorous/player.lua
+++ b/timorous/player.lua
@@ -10,8 +10,17 @@ function event_signal(e)
 		e.self:SetBoatID(838);
 		e.self:SetBoatName("Maidens_Voyage000");
 	elseif(e.signal == 2) then
-		e.self:SetBoatID(842);
-		e.self:SetBoatName("Captains_Skiff000");
+		e.self:SetBoatID(846);
+		e.self:SetBoatName("Shuttle_I000");
+	elseif(e.signal == 3) then
+		e.self:SetBoatID(847);
+		e.self:SetBoatName("Shuttle_II000");
+	elseif(e.signal == 4) then
+		e.self:SetBoatID(848);
+		e.self:SetBoatName("Shuttle_III000");
+	elseif(e.signal == 5) then
+		e.self:SetBoatID(849);
+		e.self:SetBoatName("Shuttle_IV000");
 	end
 end
 


### PR DESCRIPTION
- Requires: https://github.com/EQMacEmu/Server/pull/31
  - for: event_waypoint_arrive, event_waypoint_depart => `e.gridid` data
    - This was needed to allow the BB Shuttles to utilize different Grids

- Tested By:
  - BB -> TD -> Firiona
  - BB -> TD -> BB
    - Includes:
      - changing Shuttle that was originally zoned into TD with
      - staying on a Shuttle on a loop
  - TD -> BB
    - Includes:
      - started on Island_Shuttle
  - Firiona -> TD -> BB