### PR TITLE
TD -> Firiona & TD -> BB Zoning fixes

### DIFF
--- a/timorous/Maidens_Voyage.lua
+++ b/timorous/Maidens_Voyage.lua
@@ -27,10 +27,14 @@ function event_waypoint_arrive(e)
 				ent:Signal(1);
 			end,
 			function(ent)
+				local px = ent:GetX();
+				local py = ent:GetY();
 				local boat_id = ent:GetBoatID();
 				local diff_boat_check = boat_id == 96075 or boat_id == 846 or boat_id == 847 or boat_id == 848 or boat_id == 849;
+				-- bounding box of Maiden_Voyage at wp 30
+				local valid_pos_check = px >= -3000 and px <= -1700 and py >= 0 and py <= 1800;
 				-- Server thinks we're on Island_Shuttle, Shuttle_I, Shuttle_II, Shuttle_III or Shuttle_IV and are about to zone.
-				if(diff_boat_check and ent:GetX() < -2000 and ent:GetY() > 500) then
+				if(diff_boat_check and valid_pos_check) then
 					return true;
 				end
 				return false;

--- a/timorous/Shuttle_I.lua
+++ b/timorous/Shuttle_I.lua
@@ -28,8 +28,8 @@ function event_waypoint_arrive(e)
                 local py = ent:GetY();
                 local boat_id = ent:GetBoatID();
                 local diff_boat_check = boat_id == 838 or boat_id == 847 or boat_id == 848 or boat_id == 849 or boat_id == 96075;
-                -- bounding box of Shuttle_I
-                local valid_pos_check = px >= -7616 and px <= -7546 and py >= 3598 and py <= 3645;
+                -- bounding box of Shuttles
+                local valid_pos_check = px >= -7721 and px <= -7503 and py >= 3444 and py <= 3772;
                 -- Server thinks we're on Maidens_Voyage, Shuttle_II, Shuttle_III, Shuttle_IV or Island_Shuttle and are about to zone.
                 if(diff_boat_check and valid_pos_check) then
                     return true;
@@ -44,8 +44,8 @@ function event_waypoint_arrive(e)
             function(ent)
                 local px = ent:GetX();
                 local py = ent:GetY();
-                -- bounding box of Shuttle_I
-                local valid_pos_check = px >= -7616 and px <= -7546 and py >= 3598 and py <= 3645;
+                -- bounding box of Shuttles
+                local valid_pos_check = px >= -7721 and px <= -7503 and py >= 3444 and py <= 3772;
                 if(ent:GetBoatID() == 846 and valid_pos_check) then
                     return true;
                 end

--- a/timorous/Shuttle_II.lua
+++ b/timorous/Shuttle_II.lua
@@ -28,8 +28,8 @@ function event_waypoint_arrive(e)
                 local py = ent:GetY();
                 local boat_id = ent:GetBoatID();
                 local diff_boat_check = boat_id == 838 or boat_id == 846 or boat_id == 848 or boat_id == 849 or boat_id == 96075;
-                -- bounding box of Shuttle_II
-                local valid_pos_check = px >= -7609 and px <= -7550 and py >= 3559 and py <= 3602;
+                -- bounding box of Shuttles
+                local valid_pos_check = px >= -7721 and px <= -7503 and py >= 3444 and py <= 3772;
                 -- Server thinks we're on Maidens_Voyage, Shuttle_I, Shuttle_III, Shuttle_IV or Island_Shuttle and are about to zone.
                 if(diff_boat_check and valid_pos_check) then
                     return true;
@@ -44,8 +44,8 @@ function event_waypoint_arrive(e)
             function(ent)
                 local px = ent:GetX();
                 local py = ent:GetY();
-                -- bounding box of Shuttle_II
-                local valid_pos_check = px >= -7609 and px <= -7550 and py >= 3559 and py <= 3602;
+                -- bounding box of Shuttles
+                local valid_pos_check = px >= -7721 and px <= -7503 and py >= 3444 and py <= 3772;
                 if(ent:GetBoatID() == 847 and valid_pos_check) then
                     return true;
                 end

--- a/timorous/Shuttle_III.lua
+++ b/timorous/Shuttle_III.lua
@@ -28,8 +28,8 @@ function event_waypoint_arrive(e)
                 local py = ent:GetY();
                 local boat_id = ent:GetBoatID();
                 local diff_boat_check = boat_id == 838 or boat_id == 846 or boat_id == 847 or boat_id == 849 or boat_id == 96075;
-                -- bounding box of Shuttle_III
-                local valid_pos_check = px >= -7695 and px <= -7633 and py >= 3562 and py <= 3598;
+                -- bounding box of Shuttles
+                local valid_pos_check = px >= -7721 and px <= -7503 and py >= 3444 and py <= 3772;
                 -- Server thinks we're on Maidens_Voyage, Shuttle_I, Shuttle_II, Shuttle_IV or Island_Shuttle and are about to zone.
                 if(diff_boat_check and valid_pos_check) then
                     return true;
@@ -44,8 +44,8 @@ function event_waypoint_arrive(e)
             function(ent)
                 local px = ent:GetX();
                 local py = ent:GetY();
-                -- bounding box of Shuttle_III
-                local valid_pos_check = px >= -7695 and px <= -7633 and py >= 3562 and py <= 3598;
+                -- bounding box of Shuttles
+                local valid_pos_check = px >= -7721 and px <= -7503 and py >= 3444 and py <= 3772;
                 if(ent:GetBoatID() == 848 and valid_pos_check) then
                     return true;
                 end

--- a/timorous/Shuttle_IV.lua
+++ b/timorous/Shuttle_IV.lua
@@ -28,8 +28,8 @@ function event_waypoint_arrive(e)
                 local py = ent:GetY();
                 local boat_id = ent:GetBoatID();
                 local diff_boat_check = boat_id == 838 or boat_id == 846 or boat_id == 847 or boat_id == 848 or boat_id == 96075;
-                -- bounding box of Shuttle_IV
-                local valid_pos_check = px >= -7696 and px <= -7634 and py >= 3602 and py <= 3640;
+                -- bounding box of Shuttles
+                local valid_pos_check = px >= -7721 and px <= -7503 and py >= 3444 and py <= 3772;
                 -- Server thinks we're on Maidens_Voyage, Shuttle_I, Shuttle_II, Shuttle_III or Island_Shuttle and are about to zone.
                 if(diff_boat_check and valid_pos_check) then
                     return true;
@@ -44,8 +44,8 @@ function event_waypoint_arrive(e)
             function(ent)
                 local px = ent:GetX();
                 local py = ent:GetY();
-                -- bounding box of Shuttle_IV
-                local valid_pos_check = px >= -7696 and px <= -7634 and py >= 3602 and py <= 3640;
+                -- bounding box of Shuttles
+                local valid_pos_check = px >= -7721 and px <= -7503 and py >= 3444 and py <= 3772;
                 if(ent:GetBoatID() == 849 and valid_pos_check) then
                     return true;
                 end


### PR DESCRIPTION
- fix for `Maiden_Voyage` zoning process bounding box, this is now a large bounding box that encompasses the entire ship at waypoint 30 (there were areas on the ship wouldn't trigger the zone, such as above the stairs)
  - Tested By:
    - Verifying zoning is successful at furthest accessible points on `Miaden_Voyage`
      - This failed zoning situation only occurs when you were on a prior boat: (96705, 846, 847, 848, 849)

- normalizing the bounding box of the Shuttles return point, this allows clients to stand on any location of the shuttle (shuttles are staggered enough on returning that this allows normalization to be okay & non-interfering)
  - Tested By:
    - Standing as close to the corners of Shuttles & verifying zoning occurs correctly