### PR TITLE
Consistently random waves

### DIFF
--- a/acrylia/encounters/HighPriest.lua
+++ b/acrylia/encounters/HighPriest.lua
@@ -50,6 +50,7 @@ function ShackleTimer(e)
 				if(wave == 31) then
 					eq.get_entity_list():GetMobByNpcTypeID(154107):Shout("Master, the tresspassers persist. I beg, make them pay for their foolishness!");
 				end				
+				rand = math.random(1,2);
 				if(rand == 2) then
 					eq.spawn2(154021,9,0,150,-690,2,0);
 					eq.spawn2(154021,9,0,153,-695,2,0);


### PR DESCRIPTION
Currently, the 3rd type of waves lose their randomness. The quantity depends on the last wave of the 2nd type of wave, and is consistent until the boss spawns. The check for the "rand" variable and logic branches leading to different behavior, along with the missing definition in this scope suggest an oversight. This change makes the quantity random each time, just like the 2 types of waves before it. 